### PR TITLE
Feature/add missing sheets

### DIFF
--- a/break.js
+++ b/break.js
@@ -21,6 +21,16 @@ import { ActiveEffectsPanel } from "./module/apps/active-effects-list.js";
 import { BreakQuirkSheet } from "./module/items/quirk-sheet.js";
 import { BreakGiftSheet } from "./module/items/gift-sheet.js";
 import { BreakBookSheet } from "./module/items/book-sheet.js";
+import { BreakCombustibleSheet } from "./module/items/combustible-sheet.js";
+import { BreakConsumableSheet } from "./module/items/consumable-sheet.js";
+import { BreakCuriositySheet } from "./module/items/curiosity-sheet.js";
+import { BreakOtherworldSheet } from "./module/items/otherworld-sheet.js";
+import { BreakMiscellaneousSheet } from "./module/items/miscellaneous-sheet.js";
+import { BreakOutfitSheet } from "./module/items/outfit-sheet.js";
+import { BreakAccessorySheet } from "./module/items/accessory-sheet.js";
+import { BreakKitSheet } from "./module/items/kit-sheet.js";
+import { BreakWayfindingSheet } from "./module/items/wayfinding-sheet.js";
+import { BreakIlluminationSheet } from "./module/items/illumination-sheet.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -75,6 +85,16 @@ Hooks.once("init", async function() {
   Items.registerSheet("break", BreakQuirkSheet, { types: ['quirk'], makeDefault: true });
   Items.registerSheet("break", BreakGiftSheet, { types: ['gift'], makeDefault: true });
   Items.registerSheet("break", BreakBookSheet, { types: ['book'], makeDefault: true });
+  Items.registerSheet("break", BreakCombustibleSheet, { types: ['combustible'], makeDefault: true });
+  Items.registerSheet("break", BreakConsumableSheet, { types: ['consumable'], makeDefault: true });
+  Items.registerSheet("break", BreakCuriositySheet, { types: ['curiosity'], makeDefault: true });
+  Items.registerSheet("break", BreakOtherworldSheet, { types: ['otherworld'], makeDefault: true });
+  Items.registerSheet("break", BreakMiscellaneousSheet, { types: ['miscellaneous'], makeDefault: true });
+  Items.registerSheet("break", BreakOutfitSheet, { types: ['outfit'], makeDefault: true });
+  Items.registerSheet("break", BreakAccessorySheet, { types: ['accessory'], makeDefault: true });
+  Items.registerSheet("break", BreakKitSheet, { types: ['kit'], makeDefault: true });
+  Items.registerSheet("break", BreakWayfindingSheet, { types: ['wayfinding'], makeDefault: true });
+  Items.registerSheet("break", BreakIlluminationSheet, { types: ['illumination'], makeDefault: true });
 
   // Register system settings
   game.settings.register("break", "macroShorthand", {

--- a/break.js
+++ b/break.js
@@ -18,6 +18,8 @@ import { BreakArmorSheet } from "./module/items/armor-sheet.js";
 import { BreakArmorTypeSheet } from "./module/items/armor-type-sheet.js";
 import { BreakInjurySheet } from "./module/items/injury-sheet.js";
 import { ActiveEffectsPanel } from "./module/apps/active-effects-list.js";
+import { BreakQuirkSheet } from "./module/items/quirk-sheet.js";
+import { BreakGiftSheet } from "./module/items/gift-sheet.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -69,6 +71,8 @@ Hooks.once("init", async function() {
   Items.registerSheet("break", BreakWeaponTypeSheet, {types:['weapon-type'], makeDefault: true });
   Items.registerSheet("break", BreakArmorTypeSheet, {types:['armor-type'], makeDefault: true });
   Items.registerSheet("break", BreakInjurySheet, {types:['injury'], makeDefault: true });
+  Items.registerSheet("break", BreakQuirkSheet, { types: ['quirk'], makeDefault: true });
+  Items.registerSheet("break", BreakGiftSheet, { types: ['gift'], makeDefault: true });
 
   // Register system settings
   game.settings.register("break", "macroShorthand", {

--- a/break.js
+++ b/break.js
@@ -20,6 +20,7 @@ import { BreakInjurySheet } from "./module/items/injury-sheet.js";
 import { ActiveEffectsPanel } from "./module/apps/active-effects-list.js";
 import { BreakQuirkSheet } from "./module/items/quirk-sheet.js";
 import { BreakGiftSheet } from "./module/items/gift-sheet.js";
+import { BreakBookSheet } from "./module/items/book-sheet.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -73,6 +74,7 @@ Hooks.once("init", async function() {
   Items.registerSheet("break", BreakInjurySheet, {types:['injury'], makeDefault: true });
   Items.registerSheet("break", BreakQuirkSheet, { types: ['quirk'], makeDefault: true });
   Items.registerSheet("break", BreakGiftSheet, { types: ['gift'], makeDefault: true });
+  Items.registerSheet("break", BreakBookSheet, { types: ['book'], makeDefault: true });
 
   // Register system settings
   game.settings.register("break", "macroShorthand", {

--- a/module/actors/actor-sheet.js
+++ b/module/actors/actor-sheet.js
@@ -2,7 +2,7 @@ import { parseInputDelta } from "../../utils/utils.mjs";
 import { RANK_XP} from "../constants.js";
 import { BreakItem } from "../items/item.js";
 
-const allowedItemTypes = ["quirk", "ability", "gift", "weapon", "armor"]
+const allowedItemTypes = ["quirk", "ability", "gift", "accessory", "armor", "book", "combustible", "consumable", "curiosity", "illumination", "kit", "miscellaneous", "otherworld", "outfit", "shield", "wayfinding", "weapon"]
 
 /**
  * Extend the basic ActorSheet with some very simple modifications

--- a/module/items/accessory-sheet.js
+++ b/module/items/accessory-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakAccessorySheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "accessory"],
+      template: "systems/break/templates/items/accessory-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/book-sheet.js
+++ b/module/items/book-sheet.js
@@ -1,0 +1,52 @@
+import { BreakItemSheet } from "./item-sheet.js";
+
+export class BreakBookSheet extends BreakItemSheet {
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["break", "sheet", "book"],
+      template: "systems/break/templates/items/book-sheet.hbs",
+      width: 600,
+      height: 480,
+      dragDrop: [{dragSelector: null, dropSelector: null}]
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getData(options) {
+    const context = await super.getData(options);
+    context.descriptionHTML = await TextEditor.enrichHTML(context.item.system.description, {
+      secrets: this.document.isOwner,
+      async: true
+    });
+    context.isBook = true;
+    context.abilities = context.item.system.abilities ?? [];
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    if ( !this.isEditable ) return;
+  }
+
+  /** @inheritdoc */
+  async _onDrop(event) {
+    const data = TextEditor.getDragEventData(event);
+    if (data.type !== "Item") return;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getSubmitData(updateData) {
+    let formData = super._getSubmitData(updateData);
+    return formData;
+  }
+}

--- a/module/items/combustible-sheet.js
+++ b/module/items/combustible-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakCombustibleSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "combustible"],
+      template: "systems/break/templates/items/combustible-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/consumable-sheet.js
+++ b/module/items/consumable-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakConsumableSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "consumable"],
+      template: "systems/break/templates/items/consumable-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/curiosity-sheet.js
+++ b/module/items/curiosity-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakCuriositySheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "curiosity"],
+      template: "systems/break/templates/items/curiosity-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/gift-sheet.js
+++ b/module/items/gift-sheet.js
@@ -1,0 +1,46 @@
+import BREAK from "../constants.js";
+import { BreakItemSheet } from "./item-sheet.js";
+
+export class BreakGiftSheet extends BreakItemSheet {
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["break", "sheet", "gift"],
+      template: "systems/break/templates/items/gift-sheet.hbs",
+      width: 520,
+      height: 480,
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getData(options) {
+    const context = await super.getData(options);
+    context.descriptionHTML = await TextEditor.enrichHTML(context.item.system.description, {
+      secrets: this.document.isOwner,
+      async: true
+    });
+    context.abilityTypes = BREAK.ability_types;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    // Everything below here is only needed if the sheet is editable
+    if ( !this.isEditable ) return;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getSubmitData(updateData) {
+    let formData = super._getSubmitData(updateData);
+    return formData;
+  }
+}

--- a/module/items/illumination-sheet.js
+++ b/module/items/illumination-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakIlluminationSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "illumination"],
+      template: "systems/break/templates/items/illumination-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/kit-sheet.js
+++ b/module/items/kit-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakKitSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "kit"],
+      template: "systems/break/templates/items/kit-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/miscellaneous-sheet.js
+++ b/module/items/miscellaneous-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakMiscellaneousSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "miscellaneous"],
+      template: "systems/break/templates/items/miscellaneous-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/otherworld-sheet.js
+++ b/module/items/otherworld-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakOtherworldSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "otherworld"],
+      template: "systems/break/templates/items/otherworld-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/outfit-sheet.js
+++ b/module/items/outfit-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakOutfitSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "outfit"],
+      template: "systems/break/templates/items/outfit-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/module/items/quirk-sheet.js
+++ b/module/items/quirk-sheet.js
@@ -1,0 +1,46 @@
+import BREAK from "../constants.js";
+import { BreakItemSheet } from "./item-sheet.js";
+
+export class BreakQuirkSheet extends BreakItemSheet {
+
+  /** @inheritdoc */
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["break", "sheet", "quirk"],
+      template: "systems/break/templates/items/quirk-sheet.hbs",
+      width: 520,
+      height: 480,
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getData(options) {
+    const context = await super.getData(options);
+    context.descriptionHTML = await TextEditor.enrichHTML(context.item.system.description, {
+      secrets: this.document.isOwner,
+      async: true
+    });
+    context.abilityTypes = BREAK.ability_types;
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    // Everything below here is only needed if the sheet is editable
+    if ( !this.isEditable ) return;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getSubmitData(updateData) {
+    let formData = super._getSubmitData(updateData);
+    return formData;
+  }
+}

--- a/module/items/wayfinding-sheet.js
+++ b/module/items/wayfinding-sheet.js
@@ -1,12 +1,12 @@
 import { BreakItemSheet } from "./item-sheet.js";
 
-export class BreakBookSheet extends BreakItemSheet {
+export class BreakWayfindingSheet extends BreakItemSheet {
 
   /** @inheritdoc */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["break", "sheet", "book"],
-      template: "systems/break/templates/items/book-sheet.hbs",
+      classes: ["break", "sheet", "wayfinding"],
+      template: "systems/break/templates/items/wayfinding-sheet.hbs",
       width: 600,
       height: 480,
       dragDrop: [{dragSelector: null, dropSelector: null}]
@@ -22,7 +22,7 @@ export class BreakBookSheet extends BreakItemSheet {
       secrets: this.document.isOwner,
       async: true
     });
-    context.isBook = true;
+    context.isCombustible = true;
     return context;
   }
 

--- a/templates/actors/parts/sheet-bag-content.hbs
+++ b/templates/actors/parts/sheet-bag-content.hbs
@@ -20,7 +20,7 @@
         <div style="display:flex;flex: 0;" {{#if item.equippable}}class="bag-item"{{/if}} data-id="{{item._id}}" data-type="{{item.type}}">
             <div style="text-align: center;width:40%;">
                 <a style="font-size: 16px;font-weight: 700;cursor:pointer;" class="item-link">{{item.name}}</a>
-                <p style="font-size: 12px;">{{item.type}}</p>
+                <p style="font-size: 12px;">{{localize (concat 'TYPES.Item.' item.type)}}</p>
             </div>
             <div style="display:flex; align-items:center;flex-grow:1;">
                 <label>{{localize "BREAK.Quantity"}}</label>

--- a/templates/items/accessory-sheet.hbs
+++ b/templates/items/accessory-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/book-sheet.hbs
+++ b/templates/items/book-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/combustible-sheet.hbs
+++ b/templates/items/combustible-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/consumable-sheet.hbs
+++ b/templates/items/consumable-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/curiosity-sheet.hbs
+++ b/templates/items/curiosity-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/gift-sheet.hbs
+++ b/templates/items/gift-sheet.hbs
@@ -1,0 +1,16 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    <header class="sheet-header" style="flex: 0;">
+        <img class="profile-img" src="{{data.img}}" data-edit="img" title="{{data.name}}" />
+        <div class="header-fields">
+            <h1 class="charname">
+                <input name="name" type="text" value="{{data.name}}" placeholder="Name" />
+            </h1>
+        </div>
+    </header>
+    <div class="flexcol" style="flex: 1;">
+        <div class="section-header">
+            {{localize "BREAK.Description"}}
+        </div>
+        {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+    </div>
+</form>

--- a/templates/items/illumination-sheet.hbs
+++ b/templates/items/illumination-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/kit-sheet.hbs
+++ b/templates/items/kit-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/miscellaneous-sheet.hbs
+++ b/templates/items/miscellaneous-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/otherworld-sheet.hbs
+++ b/templates/items/otherworld-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/outfit-sheet.hbs
+++ b/templates/items/outfit-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>

--- a/templates/items/quirk-sheet.hbs
+++ b/templates/items/quirk-sheet.hbs
@@ -1,0 +1,16 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    <header class="sheet-header" style="flex: 0;">
+        <img class="profile-img" src="{{data.img}}" data-edit="img" title="{{data.name}}" />
+        <div class="header-fields">
+            <h1 class="charname">
+                <input name="name" type="text" value="{{data.name}}" placeholder="Name" />
+            </h1>
+        </div>
+    </header>
+    <div class="flexcol" style="flex: 1;">
+        <div class="section-header">
+            {{localize "BREAK.Description"}}
+        </div>
+        {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+    </div>
+</form>

--- a/templates/items/wayfinding-sheet.hbs
+++ b/templates/items/wayfinding-sheet.hbs
@@ -1,0 +1,11 @@
+<form class="flexcol {{cssClass}}" autocomplete="off">
+    {{> "systems/break/templates/items/item-header.hbs"}}
+    <div style="display:flex;column-gap: 24px;">
+        <div class="flexcol" style="flex: 1;">
+            <div class="section-header">
+                {{localize "BREAK.Description"}}
+            </div>
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Added a basic sheet with the description (and slots and price for item) for these types:
- Quirk
- Gift
- Book
- Combustible
- Consumable
- Curiosity
- Otherworld
- Miscellaneous 
- Outfit
- Accessory
- Kit
- Wayfinding 
- Illumination
Added support for the new types to be displayed in chat
Added support for the new gear type to be drag into the inventory
Fixed the shown type in the inventory to use the localization

Example of a sheet with multiple different items and chat of those items
![image](https://github.com/user-attachments/assets/7136793c-d83d-44a0-849f-13a7bf6ec781)