### PR TITLE
Fix future pc sheet to have actorLink enabled by default

### DIFF
--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -12,6 +12,19 @@ export class BreakActor extends Actor {
     super.prepareDerivedData();
   }
 
+  async _preCreate(data, options, user) {
+
+    await super._preCreate(data, options, user);
+
+    let initData = {};
+
+    if (data.type === "character") {
+      initData["prototypeToken.actorLink"] = true;
+    }
+
+    this.updateSource(initData);
+  }
+
   prepareData(){
     super.prepareData();
 


### PR DESCRIPTION
The issue:
When you change the sheet of a token of your character it will not change the original sheet

The fix:
This need to be enabled
![image](https://github.com/user-attachments/assets/d81f838b-2e5f-4a10-af77-78ea4a077c3f)

So the code will make it so future character sheet will have this enabled by default but for existing sheet it will need to be enabled manually
