### PR TITLE
Fix stop Enter key in a input triggering a click on the next button

### DIFF
--- a/break.js
+++ b/break.js
@@ -295,3 +295,14 @@ Hooks.once('canvasInit', (canvas) => {
     }
   });
 });
+
+//Fix issue where if you use Enter key in a input it trigger a click on the next button
+window.addEventListener('keydown', function (e) {
+  if (e.keyIdentifier == 'U+000A' || e.keyIdentifier == 'Enter' || e.keyCode == 13) {
+    if (e.target.nodeName == 'INPUT' && (e.target.type == 'text' || e.target.type == 'number')) {
+      e.preventDefault();
+
+      return false;
+    }
+  }
+}, true);


### PR DESCRIPTION
Fix this issue:
![image](https://github.com/user-attachments/assets/c334209c-22be-46f5-b771-7b97f1d56c58)

This is a weird bug and the only fix I found was to disable the event when the enter key is use in a text input type text or number!

This doesn't affect textarea so you can still use the Enter key in a textarea

